### PR TITLE
Adding skeleton documents for governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# governance
-The governance process and model for mantid 
+# Mantid Governance
+
+The purpose of this repository is to hold documents that formalize the governance model of the Mantid project.
+It clarifies how decisions are made and how various contributors interact,
+especially the relationship between those working
+for contributing facilities and open-source collaboration.
+
+## Table of Contents
+
+* [Main Governance Document](governance.md)
+* [Contributing Facilities](facilities.md)
+* Working Groups
+  * [Scientific Working Group](scientific-working-group)
+  * [Technical Working Group](technical-working-group)

--- a/facilities.md
+++ b/facilities.md
@@ -1,0 +1,13 @@
+# Contributing Facilities
+
+This document lists the abbreviations and full names of facilities
+who have nominated members on one of the [working groups](governance.md).
+
+* ANSTO - [Australian Nuclear Science and Technology Organisation](https://www.ansto.gov.au/) (Australia)
+* CSNS - [China Spallation Neutron Source](http://english.ihep.cas.cn/csns/) (China)
+* ESS - [European Spallation Source](https://europeanspallationsource.se/) (Denmark/Sweden)
+* ILL - [Institut Laue-Langevin](https://www.ill.eu/) (France)
+* JCNS - [Jülich Centre for Neutron Science](https://www.fz-juelich.de/jcns/EN/Home/home_node.html) (Germany)
+* ORNL - [Oak Ridge National Laboratory](https://www.ornl.gov/) (USA)
+* PSI - [Paul Scherrer Institute](https://www.psi.ch/en) (Switzerland)
+* STFC - [Science and Facilities Technology Council](https://stfc.ukri.org/) (UK)

--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,3 @@
+# Governance Document
+
+This is a placeholder for the main governance document that requires translating from the private transition document previously shared amongst collaborators.

--- a/scientific-working-group/README.md
+++ b/scientific-working-group/README.md
@@ -1,0 +1,3 @@
+# Scientific Working Group
+
+This folder contains documents relating to the Scientific Working Group.

--- a/technical-working-group/README.md
+++ b/technical-working-group/README.md
@@ -1,0 +1,8 @@
+# Technical Working Group
+
+This folder contains documents relating to the Technical Working Group.
+
+## Table of Contents
+
+* [Meeting Minutes](minutes)
+* [Members](people.md)

--- a/technical-working-group/people.md
+++ b/technical-working-group/people.md
@@ -1,0 +1,18 @@
+# Technical Working Group Membership
+
+This documents lists the voting members and their [facility affiliations](../facilities.md).
+
+## Members
+
+* Shenglan Chen (CSNS)
+* Rong Du (CSNS)
+* Martyn Gigg (STFC) - **Chair**
+* Gemma Guest (STFC)
+* Marina Ganeva (JCNS)
+* Nick Hauser (ANSTO)
+* Simon Heybrock (ESS)
+* Zach Morgan (ORNL)
+* Pete Peterson (ORNL)
+* Mathieu Tillet (ILL)
+* Emmanouela Rantsiou (PSI)
+* Gagik Vardanyan (ILL)


### PR DESCRIPTION
### Description

Adds an initial set of documents in order to start creating a layout within the repository.

I have added the members of the technical working group along with a document describing the facility abbreviations.

The current governance document is in a private document that has been shared with the members. It needs translating into an open document in this repository but that is a task outside of the scope of setting up the layout. See issue #1.